### PR TITLE
TAS-688/Enter-Pass

### DIFF
--- a/src/components/Input/index.module.scss
+++ b/src/components/Input/index.module.scss
@@ -56,6 +56,7 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
+    text-align: left;
     color: $gray;
 }
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -44,7 +44,7 @@ const Input: React.FC<InputProps> = ({
           value={value}
           onChange={onChange}
           className={styles['input']}
-          {...register(name)}
+          {...(register ? register(name) : {})}
         />
         {hasPostfixIcon && (
           <InputGroup.Text onClick={handlePostfixClick} className={styles['postfix']}>

--- a/src/pages/Backup/index.services.ts
+++ b/src/pages/Backup/index.services.ts
@@ -71,6 +71,7 @@ export const useBackup = () => {
     try {
       const { mnemonics: newMnemonics, privateKey: newPrivateKey, did: newDID } = await createDID([exampleService]);
       await pluto.storeDID(newDID, newPrivateKey, 'master');
+      //FIXME: save into local storage for now
       localStorage.setItem('mnemonics', newMnemonics.toString());
       setMnemonics(newMnemonics);
       console.log('New DID created');

--- a/src/pages/CreatePass/index.services.ts
+++ b/src/pages/CreatePass/index.services.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 export const useCreatePass = () => {
   const { t: translate } = useTranslation();
   const navigate = useNavigate();
+  const { hash = '' } = useLocation();
   const [passcode, setPasscode] = useState('');
   const [isFirstStep, setIsFirstStep] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
@@ -18,7 +19,7 @@ export const useCreatePass = () => {
     if (pass === passcode) {
       //FIXME: change the logic later
       localStorage.setItem('passcode', pass);
-      navigate('/created');
+      navigate(`/created${hash}`);
     } else {
       setErrorMessage(translate('create-pass-error'));
     }

--- a/src/pages/EnterPass/index.module.scss
+++ b/src/pages/EnterPass/index.module.scss
@@ -1,0 +1,21 @@
+.title {
+    font-size: 24px;
+    font-weight: 600;
+    line-height: 32px;
+    color: $black;
+    text-align: center;
+}
+
+.subtitle,
+.error {
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px;
+    color: $gray;
+    text-align: center;
+}
+
+.error {
+    font-weight: 500;
+    color: $color-red-2;
+}

--- a/src/pages/EnterPass/index.services.ts
+++ b/src/pages/EnterPass/index.services.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import i18next from 'i18next';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import SDK from '@hyperledger/identus-edge-agent-sdk';
+import { decrypt } from 'src/services/backup';
+import { recoverDID } from 'src/services/dids';
+import { useAppContext } from 'src/store/context';
+import { passwordPattern } from 'src/utilities';
+
+export const useEnterPass = () => {
+  const { t: translate } = useTranslation();
+  const navigate = useNavigate();
+  const { state, dispatch } = useAppContext();
+  const { did, encrypted, pluto } = state || {};
+  const [schema, setSchema] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const exampleService = new SDK.Domain.Service('didcomm', ['DIDCommMessaging'], {
+    uri: 'https://example.com/endpoint',
+    accept: ['didcomm/v2'],
+    routingKeys: ['did:example:somemediator#somekey'],
+  });
+
+  useEffect(() => {
+    if (i18next.isInitialized) {
+      setSchema(createSchema());
+    } else {
+      i18next.on('initialized', () => {
+        setSchema(createSchema());
+      });
+    }
+  }, []);
+
+  const createSchema = () =>
+    yup.object().shape({
+      password: yup
+        .string()
+        .required(i18next.t('enter-pass-form.input-error1'))
+        .min(8, i18next.t('enter-pass-form.input-error2'))
+        .matches(passwordPattern, i18next.t('enter-pass-form.input-error3')),
+    });
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm({
+    resolver: yupResolver<{ password: string }>(schema),
+  });
+  const password = watch('password');
+
+  const onSubmit = async (formData: { password: string }) => {
+    const { password } = formData || {};
+    try {
+      const encoder = new TextEncoder();
+      const encodedPassword = encoder.encode(password);
+      const mnemonics = await JSON.parse(decrypt(encodedPassword, encrypted));
+      if (mnemonics.length) {
+        const { did: newDID, privateKey, mnemonics: newMnemonics } = await recoverDID(mnemonics, [exampleService]);
+        dispatch({ type: 'SET_MNEMONICS', payload: newMnemonics });
+        //FIXME: save into local storage for now
+        localStorage.setItem('mnemonics', newMnemonics.toString());
+        await pluto.storeDID(newDID, privateKey, 'master');
+        dispatch({ type: 'SET_DID', payload: newDID });
+        navigate('/setup-pass#restored');
+      }
+    } catch {
+      setErrorMessage(translate('enter-pass-form.submit-error'));
+    }
+  };
+
+  return {
+    translate,
+    navigate,
+    did,
+    encrypted,
+    register,
+    errors,
+    password,
+    handleSubmit,
+    onSubmit,
+    errorMessage,
+  };
+};

--- a/src/pages/EnterPass/index.tsx
+++ b/src/pages/EnterPass/index.tsx
@@ -1,0 +1,51 @@
+import { Navigate } from 'react-router-dom';
+import Card from 'src/components/Card';
+import { useEnterPass } from './index.services';
+import styles from './index.module.scss';
+import Input from 'src/components/Input';
+
+function EnterPass() {
+  const { translate, navigate, did, encrypted, register, errors, password, handleSubmit, onSubmit, errorMessage } =
+    useEnterPass();
+
+  if (did) return <Navigate to="/" />;
+  else if (!encrypted) return <Navigate to="/import" />;
+  return (
+    <form className="h-100 d-flex align-items-center justify-content-center" onSubmit={handleSubmit(onSubmit)}>
+      <Card
+        contentClassName="justify-content-start align-items-stretch pt-5 text-center gap-4"
+        buttons={[
+          {
+            children: translate('enter-pass-continue-button'),
+            variant: 'primary',
+            type: 'submit',
+            disabled: !password,
+            className: 'fw-semibold w-100 py-2',
+          },
+          {
+            children: translate('enter-pass-back-button'),
+            variant: 'light',
+            className: 'fw-semibold w-100 py-2',
+            onClick: () => navigate('/import'),
+          },
+        ]}
+      >
+        <div className="d-flex flex-column gap-2">
+          <h4 className={styles['title']}>{translate('enter-pass-title')}</h4>
+          <span className={styles['subtitle']}>{translate('enter-pass-subtitle')}</span>
+        </div>
+        <Input
+          register={register}
+          name="password"
+          type="password"
+          placeholder={translate('enter-pass-form.input-placeholder')}
+          hasPostfixIcon
+          errorMessage={errors['password']?.message ? errors['password'].message.toString() : ''}
+        />
+        {errorMessage && <span className={styles['error']}>{errorMessage}</span>}
+      </Card>
+    </form>
+  );
+}
+
+export default EnterPass;

--- a/src/pages/Intro/index.services.ts
+++ b/src/pages/Intro/index.services.ts
@@ -20,16 +20,12 @@ export const useIntro = () => {
         accept: ['didcomm/v2'],
         routingKeys: ['did:example:somemediator#somekey'],
       });
-      const {
-        mnemonics: currentMnemonics,
-        privateKey: currentPrivateKey,
-        did: currentDID,
-      } = await createDID([exampleService]);
-      dispatch({ type: 'SET_MNEMONICS', payload: mnemonics });
+      const { mnemonics: newMnemonics, privateKey: newPrivateKey, did: newDID } = await createDID([exampleService]);
+      dispatch({ type: 'SET_MNEMONICS', payload: newMnemonics });
       //FIXME: save into local storage for now
-      localStorage.setItem('mnemonics', currentMnemonics.toString());
-      await pluto.storeDID(currentDID, currentPrivateKey, 'master');
-      dispatch({ type: 'SET_DID', payload: currentDID });
+      localStorage.setItem('mnemonics', newMnemonics.toString());
+      await pluto.storeDID(newDID, newPrivateKey, 'master');
+      dispatch({ type: 'SET_DID', payload: newDID });
       navigate('/setup-pass');
     } catch (e) {
       console.error('Error in creating wallet or saving seed phrase:', e);

--- a/src/pages/Intro/index.services.ts
+++ b/src/pages/Intro/index.services.ts
@@ -9,8 +9,6 @@ export const useIntro = () => {
   const navigate = useNavigate();
   const { state, dispatch } = useAppContext();
   const { did, mnemonics, pluto } = state || {};
-  //FIXME: localStorage
-  const passcode = localStorage.getItem('passcode') || '';
 
   const onCreateWallet = async () => {
     try {
@@ -32,5 +30,5 @@ export const useIntro = () => {
     }
   };
 
-  return { translate, navigate, did, onCreateWallet, passcode };
+  return { translate, navigate, did, onCreateWallet };
 };

--- a/src/pages/Intro/index.tsx
+++ b/src/pages/Intro/index.tsx
@@ -5,40 +5,38 @@ import { useIntro } from './index.services';
 import styles from './index.module.scss';
 
 function Intro() {
-  const { translate, navigate, did, passcode, onCreateWallet } = useIntro();
+  const { translate, navigate, did, onCreateWallet } = useIntro();
 
-  if (!did) {
-    return (
-      <div className="h-100 d-flex align-items-center justify-content-center">
-        <Card
-          buttons={[
-            {
-              children: translate('intro-create-button'),
-              variant: 'primary',
-              className: 'fw-semibold w-100 py-2',
-              onClick: onCreateWallet,
-            },
-            {
-              children: translate('intro-restore-button'),
-              variant: 'light',
-              className: 'fw-semibold w-100 py-2',
-              onClick: () => navigate('/import'),
-            },
-          ]}
-        >
-          <div className="mb-3">
-            <img src={logo} width={56} height={56} alt="Socious" className={styles['logo']} />
-          </div>
-          <h4 className={styles['title']}>{translate('intro-welcome')}</h4>
-          <div className={styles['subtitle']}>
-            {translate('intro-title')}
-            <span>{translate('intro-subtitle')}</span>
-          </div>
-        </Card>
-      </div>
-    );
-  }
-  return <Navigate to={passcode ? '/' : '/setup-pass'} />;
+  if (did) return <Navigate to="/" />;
+  return (
+    <div className="h-100 d-flex align-items-center justify-content-center">
+      <Card
+        buttons={[
+          {
+            children: translate('intro-create-button'),
+            variant: 'primary',
+            className: 'fw-semibold w-100 py-2',
+            onClick: onCreateWallet,
+          },
+          {
+            children: translate('intro-restore-button'),
+            variant: 'light',
+            className: 'fw-semibold w-100 py-2',
+            onClick: () => navigate('/import'),
+          },
+        ]}
+      >
+        <div className="mb-3">
+          <img src={logo} width={56} height={56} alt="Socious" className={styles['logo']} />
+        </div>
+        <h4 className={styles['title']}>{translate('intro-welcome')}</h4>
+        <div className={styles['subtitle']}>
+          {translate('intro-title')}
+          <span>{translate('intro-subtitle')}</span>
+        </div>
+      </Card>
+    </div>
+  );
 }
 
 export default Intro;

--- a/src/pages/Recover/index.services.ts
+++ b/src/pages/Recover/index.services.ts
@@ -21,10 +21,14 @@ const useRecover = () => {
     const file = files[0];
     if (file && file.name.endsWith('.enc')) {
       const reader = new FileReader();
-      reader.onload = e =>
-        e.target?.result && dispatch({ type: 'SET_ENCRYPTED_DATA', payload: e.target.result as string });
+      reader.onload = e => {
+        const encryptedData = e.target?.result as string;
+        if (encryptedData) {
+          dispatch({ type: 'SET_ENCRYPTED_DATA', payload: encryptedData });
+          navigate('/enter-pass');
+        }
+      };
       reader.readAsText(file);
-      navigate('/enter-pass');
     } else {
       setErrorMessage(translate('recover-error'));
     }

--- a/src/pages/Settings/index.services.ts
+++ b/src/pages/Settings/index.services.ts
@@ -77,6 +77,8 @@ const useSettings = () => {
     dbs.forEach(db => {
       indexedDB.deleteDatabase(db.name);
     });
+    localStorage.removeItem('passcode');
+    localStorage.removeItem('mnemonics');
     window.location.assign('/intro');
   };
 

--- a/src/pages/SetupPass/index.services.ts
+++ b/src/pages/SetupPass/index.services.ts
@@ -1,9 +1,10 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 export const useSetupPass = () => {
   const { t: translate } = useTranslation();
   const navigate = useNavigate();
+  const { hash = '' } = useLocation();
 
-  return { translate, navigate };
+  return { translate, navigate, hash };
 };

--- a/src/pages/SetupPass/index.tsx
+++ b/src/pages/SetupPass/index.tsx
@@ -3,7 +3,7 @@ import { useSetupPass } from './index.services';
 import styles from './index.module.scss';
 
 function SetupPass() {
-  const { translate, navigate } = useSetupPass();
+  const { translate, navigate, hash } = useSetupPass();
 
   return (
     <div className="h-100 d-flex align-items-center justify-content-center">
@@ -14,7 +14,7 @@ function SetupPass() {
             children: translate('setup-pass-title'),
             variant: 'primary',
             className: 'fw-semibold w-100 py-2',
-            onClick: () => navigate('/create-pass'),
+            onClick: () => navigate(`/create-pass${hash}`),
           },
           {
             children: translate('setup-pass-back'),

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,7 +3,7 @@ import { RouteObject, createBrowserRouter, Navigate, useRouteError } from 'react
 import { useAppContext } from 'src/store/context';
 import Layout from 'src/containers/Layout';
 import Intro from 'src/pages/Intro';
-import Register from 'src/pages/Register';
+// import Register from 'src/pages/Register';
 // import Confirm from 'src/pages/Confirm';
 import Created from 'src/pages/Created';
 import Recover from 'src/pages/Recover';
@@ -51,6 +51,7 @@ export const blueprint: RouteObject[] = [
 function DefaultRoute(): JSX.Element {
   const { state } = useAppContext();
   const shouldRenderCredentials = !state.didLoading && state.did;
+  const hasPasscode = localStorage.getItem('passcode') || '';
   return (
     <>
       {state.didLoading ? (
@@ -60,7 +61,7 @@ function DefaultRoute(): JSX.Element {
           <AppUrlListener />
           {state.device.platform === 'web' && !config.DEBUG && <Navigate to="/download" />}
           {!shouldRenderCredentials && <Navigate to="/intro" />}
-          {shouldRenderCredentials && <Credentials />}
+          {shouldRenderCredentials && (hasPasscode ? <Credentials /> : <Navigate to="/setup-pass" />)}
         </>
       )}
     </>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import AppUrlListener from 'src/containers/AppUrlListener';
 import Settings from 'src/pages/Settings';
 import SetupPass from 'src/pages/SetupPass';
 import CreatePass from 'src/pages/CreatePass';
+import EnterPass from 'src/pages/EnterPass';
 import Backup from 'src/pages/Backup';
 import { config } from 'src/config';
 
@@ -34,8 +35,9 @@ export const blueprint: RouteObject[] = [
       { path: '/intro', element: <Intro /> },
       { path: '/setup-pass', element: <SetupPass /> },
       { path: '/create-pass', element: <CreatePass /> },
-      // { path: '/register', element: <Register /> },
+      { path: '/enter-pass', element: <EnterPass /> },
       { path: '/backup', element: <Backup /> },
+      // { path: '/register', element: <Register /> },
       // { path: '/confirm', element: <Confirm /> },
       { path: '/created', element: <Created /> },
       { path: '/verify', element: <Verify /> },

--- a/src/translations/locales/en/enter-pass.json
+++ b/src/translations/locales/en/enter-pass.json
@@ -1,0 +1,13 @@
+{
+  "enter-pass-title": "Enter password",
+  "enter-pass-subtitle": "You need this to import this wallet",
+  "enter-pass-continue-button": "Continue",
+  "enter-pass-back-button": "Back",
+  "enter-pass-form": {
+    "input-placeholder": "Enter your password...",
+    "input-error1": "Password is required",
+    "input-error2": "Minimum 8 characters",
+    "input-error3": "Password complexity is week",
+    "submit-error": "An error occurred in importing wallet"
+  }
+}

--- a/src/translations/locales/en/translation.ts
+++ b/src/translations/locales/en/translation.ts
@@ -10,6 +10,7 @@ import settings from './settings.json';
 import credentials from './credentials.json';
 import setupPass from './setup-pass.json';
 import createPass from './create-pass.json';
+import enterPass from './enter-pass.json';
 import backup from './backup.json';
 import general from './general.json';
 
@@ -28,6 +29,7 @@ export function generateTranslationFile() {
     credentials,
     setupPass,
     createPass,
+    enterPass,
     backup,
     general,
   );

--- a/src/translations/locales/jp/enter-pass.json
+++ b/src/translations/locales/jp/enter-pass.json
@@ -1,0 +1,13 @@
+{
+  "enter-pass-title": "パスワードを入力",
+  "enter-pass-subtitle": "このパスワードがウォレットのインポートに必要です",
+  "enter-pass-continue-button": "続ける",
+  "enter-pass-back-button": "戻る",
+  "enter-pass-form": {
+    "input-placeholder": "パスワードを入力してください...",
+    "input-error1": "パスワードは必須です",
+    "input-error2": "8文字以上で入力してください",
+    "input-error3": "パスワードの複雑さが不十分です",
+    "submit-error": "ウォレットのインポート中にエラーが発生しました"
+  }
+}

--- a/src/translations/locales/jp/translation.ts
+++ b/src/translations/locales/jp/translation.ts
@@ -10,6 +10,7 @@ import settings from './settings.json';
 import credentials from './credentials.json';
 import setupPass from './setup-pass.json';
 import createPass from './create-pass.json';
+import enterPass from './enter-pass.json';
 import backup from './backup.json';
 import general from './general.json';
 
@@ -28,6 +29,7 @@ export function generateTranslationFile() {
     credentials,
     setupPass,
     createPass,
+    enterPass,
     backup,
     general,
   );


### PR DESCRIPTION
**This branch is related to the `Enter passcode` page after importing the existing wallet.**

- [x] implement enter password page 
- [x] decrypt saved imported file content and entered password 
- [x] recover wallet
- [x] go to `/setup-pass` and `/create-pass` and save into local storage
- [x] redirect to `/created#restored` page 
- [x] translations

**Also,** includes:
- [x] fixed input `error` style and empty `register` prop
- [x] refactored `remove wallet` logic and clear all local storage
- [x] handled default route when `passcode` is not set 

TODO:
- [x] final check
- [x] other branches should be merged first