### PR TITLE
Fix/Setup-Pass-Back-Button

### DIFF
--- a/src/pages/SetupPass/index.tsx
+++ b/src/pages/SetupPass/index.tsx
@@ -16,12 +16,12 @@ function SetupPass() {
             className: 'fw-semibold w-100 py-2',
             onClick: () => navigate(`/create-pass${hash}`),
           },
-          {
-            children: translate('setup-pass-back'),
-            variant: 'light',
-            className: 'fw-semibold w-100 py-2',
-            onClick: () => navigate('/intro'),
-          },
+          // {
+          //   children: translate('setup-pass-back'),
+          //   variant: 'light',
+          //   className: 'fw-semibold w-100 py-2',
+          //   onClick: () => navigate('/intro'),
+          // },
         ]}
       >
         <h4 className={styles['title']}>{translate('setup-pass-title')}</h4>


### PR DESCRIPTION
**FIX:**
- [x] because setting a passcode is a mandatory step, when user's wallet is created and passcode is not set, user can to go back to `/intro` page