### PR TITLE
TAS-2753/Fix-Processing-Credentials-Alert

### DIFF
--- a/src/pages/Connection/index.services.ts
+++ b/src/pages/Connection/index.services.ts
@@ -49,7 +49,7 @@ const useConnection = () => {
           .then(r => console.log(`callback successfully with status ${r.status}`))
           .catch(err => console.log(err));
       navigate('/');
-      localStorage.setItem('listProcessing', 'true');
+      dispatch({ type: 'SET_LIST_PROCESSING', payload: true });
       addAction('connections', {
         oob,
         callback,

--- a/src/pages/Credentials/index.tsx
+++ b/src/pages/Credentials/index.tsx
@@ -115,8 +115,8 @@ function Credentials() {
           <CredentialAlert
             variant="warning"
             iconName="alert-warning"
-            title="Processing..."
-            subtitle="Please keep this app open as it may take a few minutes."
+            title={translate('credential-alert.processing-title')}
+            subtitle={translate('credential-alert.processing-subtitle')}
           />
         )}
         <div className={styles['card__content']}>

--- a/src/pages/Credentials/index.tsx
+++ b/src/pages/Credentials/index.tsx
@@ -17,9 +17,8 @@ import NavigationBar from 'src/containers/NavigationBar';
 function Credentials() {
   const { t: translate } = useTranslation();
   const navigate = useNavigate();
-  const listProcessing = Boolean(localStorage.getItem('listProcessing'));
   const { state } = useAppContext();
-  const { credentials, verification, submitted } = state || {};
+  const { credentials, verification, submitted, listProcessing } = state || {};
   const { id } = useParams();
   const isKyc = type => type === 'verification';
   const generateNonKycTypeText = claim => {

--- a/src/services/agent.tsx
+++ b/src/services/agent.tsx
@@ -106,7 +106,7 @@ const handleMessages =
           type: 'issued-credential',
           credential,
         });
-        localStorage.removeItem('listProcessing');
+        dispatch({ type: 'SET_LIST_PROCESSING', payload: false });
         if (!verfiedVC) {
           dispatch({ type: 'SET_VERIFICATION', payload: credential });
         }

--- a/src/store/context/index.tsx
+++ b/src/store/context/index.tsx
@@ -21,6 +21,7 @@ const initialState: StateType = {
   listenerActive: false,
   verifiedVC: {},
   encrypted: '',
+  listProcessing: false,
 };
 
 const AppContext = createContext<{
@@ -62,6 +63,8 @@ function appReducer(state: StateType, action: ActionType): StateType {
       return { ...state, verifiedVC: action.payload };
     case 'SET_ENCRYPTED_DATA':
       return { ...state, encrypted: action.payload };
+    case 'SET_LIST_PROCESSING':
+      return { ...state, listProcessing: action.payload };
     case 'LOADING_START':
       return state;
     case 'LOADING_END':

--- a/src/store/context/types.ts
+++ b/src/store/context/types.ts
@@ -23,6 +23,7 @@ export interface StateType {
   listenerActive: boolean;
   verifiedVC: any;
   encrypted: string;
+  listProcessing: boolean;
 }
 
 export type ActionType =
@@ -40,6 +41,7 @@ export type ActionType =
   | { type: 'SET_LISTENER_STATE'; payload: boolean }
   | { type: 'VERIFIED_VC'; payload: any }
   | { type: 'SET_ENCRYPTED_DATA'; payload: string }
+  | { type: 'SET_LIST_PROCESSING'; payload: boolean }
   | { type: 'LOADING_START' }
   | { type: 'LOADING_END' };
 

--- a/src/translations/locales/en/credentials.json
+++ b/src/translations/locales/en/credentials.json
@@ -12,7 +12,9 @@
     "declined-link2": "Contact us",
     "default-title": "Verification Required",
     "default-subtitle": "To receive verifiable credentials you need to verify your identity.",
-    "default-link": "Verify now"
+    "default-link": "Verify now",
+    "processing-title": "Processing...",
+    "processing-subtitle": "Please keep this app open as it may take a few minutes."
   },
   "credential-title": "Connect to an organization to receive your first credential",
   "credential-subtitle": "Receive, store and share your digital credentials",

--- a/src/translations/locales/jp/credentials.json
+++ b/src/translations/locales/jp/credentials.json
@@ -12,7 +12,9 @@
     "declined-link2": "お問い合わせ",
     "default-title": "確認が必要です",
     "default-subtitle": "検証可能な資格情報を受け取るには、本人確認が必要です。",
-    "default-link": "今すぐ確認する"
+    "default-link": "今すぐ確認する",
+    "processing-title": "処理中...",
+    "processing-subtitle": "数分かかる場合がありますので、このアプリを開いたままにしてください。"
   },
   "credential-title": "資格情報を受け取るには、組織に接続してください",
   "credential-subtitle": "デジタル資格情報を受け取り、保存し、共有する",


### PR DESCRIPTION
**FIX:**
- [x] used `context` instead of `localStorage` for saving processing list state
- [x] translations 